### PR TITLE
修复popover中字段类型字体大小

### DIFF
--- a/src/components/EditorCanvas/Table.jsx
+++ b/src/components/EditorCanvas/Table.jsx
@@ -235,7 +235,7 @@ export default function Table(props) {
                       <p className="font-bold me-4">{e.name}</p>
                       <p
                         className={
-                          "ms-4 font-mono " + dbToTypes[database][e.type].color
+                          "ms-4 font-mono text-xs " + dbToTypes[database][e.type].color
                         }
                       >
                         {e.type +


### PR DESCRIPTION
## 修改内容
- 为表格字段悬停popover中的类型显示添加 `text-xs` 字体大小
- 确保与表格内字段类型显示保持一致的字体大小

## 修改位置
- `src/components/EditorCanvas/Table.jsx:238` - 添加 `text-xs` 类到popover中的字段类型显示

## 背景
在之前的PR中，我们修改了表格内字段类型的字体大小，但遗漏了popover中的相同显示。这个修改确保了所有字段类型显示位置的字体大小保持一致。

## 测试建议
- [x] 悬停表格字段，确认popover中类型字体大小为12px
- [x] 对比表格内和popover中的字体大小，确保一致性
- [x] 在不同主题模式下验证显示效果

🤖 Generated with [Claude Code](https://claude.ai/code)